### PR TITLE
build a single wheel for cpython 3 using py_limited_api 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,8 +70,8 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.  Also upgrade setuptools.
-  - "python -m pip install --disable-pip-version-check --user --upgrade pip setuptools"
+  # about it being out of date.  Also upgrade setuptools and wheel.
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip setuptools wheel"
 
   # Fetch Argon2 submodule.
   - "git submodule init"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@
 # ensure LICENSE is included in wheels
 license_file = LICENSE
 
+[bdist_wheel]
+py_limited_api = cp34
+
 
 # Testing
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,10 @@ EXTRAS_REQUIRE = {
     "tests": ["coverage", "hypothesis", "pytest"],
 }
 EXTRAS_REQUIRE["dev"] = (
-    EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["docs"] + ["wheel", "pre-commit"]
+    EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["docs"] + [
+        "wheel>=0.30",  # required for py_limited_api option
+        "pre-commit",
+    ]
 )
 
 ###############################################################################


### PR DESCRIPTION
`wheel` 0.30.0 added a new `--py-limited-api {cp32|cp33|cp34|...}` option that produces `cpNN.abi3.{arch}` tags on CPython 3, for distributing wheels containing extension modules which define the [`Py_LIMITED_API`](https://docs.python.org/3/c-api/stable.html)

CFFI does that by default since v1.8 (see [cffi docs]( http://cffi.readthedocs.io/en/latest/cdef.html#ffibuilder-compile-etc-compiling-out-of-line-modules))

This means CFFI extension modules are now named `*.abi3.so`, and should work on any version of CPython >= 3.2 (that's when the stabe Py_LIMITED_API was first introduced).

In `setup.cfg`, I still kept the minimum version supported to 3.4.

This new bdist_wheel option should be ignored on implementations different from cpython.
  