### PR TITLE
Add env variable ARGON2_CFFI_USE_SSE2 to override sse2 optimizations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Added ``ARGON2_CFFI_USE_SSE2`` env variable to override SSE2 autodetection.
 
 
 ----

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,6 +57,16 @@ This approach can lead to problems around your build chain and you can run into 
 **It is your own responsibility to deal with these risks if you choose this path.**
 
 
+Override Automatic SSE2 Detection
+------------------------------------------
+
+If you set ``ARGON2_CFFI_USE_SSE2`` to ``1`` (and *only* ``1``), ``argon2-cffi`` will build with sse2 support.
+
+If you set ``ARGON2_CFFI_USE_SSE2`` to ``0`` (and *only* ``0``), ``argon2-cffi`` will build without sse2 support.
+
+This should generally only be used if the sse2 autodetection causes a compilation failure or if you are cross compiling.
+
+
 .. _SSE2: https://en.wikipedia.org/wiki/SSE2
 .. _PyPI: https://pypi.org/project/argon2-cffi/
 .. _CFFI environment: https://cffi.readthedocs.io/en/latest/installation.html

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,15 @@ from setuptools.command.install import install
 NAME = "argon2-cffi"
 PACKAGES = find_packages(where="src")
 
-# Optimized version requires SSE2 extensions.  They have been around since
-# 2001 so we try to compile it on every recent-ish x86.
-optimized = platform.machine() in ("i686", "x86", "x86_64", "AMD64")
+use_sse2 = os.environ.get("ARGON2_CFFI_USE_SSE2", None)
+if use_sse2 == "1":
+    optimized = True
+elif use_sse2 == "0":
+    optimized = False
+else:
+    # Optimized version requires SSE2 extensions.  They have been around since
+    # 2001 so we try to compile it on every recent-ish x86.
+    optimized = platform.machine() in ("i686", "x86", "x86_64", "AMD64")
 
 CFFI_MODULES = ["src/argon2/_ffi_build.py:ffi"]
 lib_base = os.path.join("extras", "libargon2", "src")


### PR DESCRIPTION
This is useful for cross compiling since platform.machine() is broken for cross builds.