### PR TITLE
Fixed __repr__ type-o for parallelism in Parameters class

### DIFF
--- a/src/argon2/_utils.py
+++ b/src/argon2/_utils.py
@@ -105,7 +105,7 @@ class Parameters(object):
     def __repr__(self):
         return (
             "<Parameters(type=%r, version=%d, hash_len=%d, salt_len=%d, "
-            "time_cost=%d, memory_cost=%d, parallelelism=%d)>"
+            "time_cost=%d, memory_cost=%d, parallelism=%d)>"
             % (
                 self.type,
                 self.version,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,7 +136,7 @@ class TestParameters(object):
         """
         assert (
             "<Parameters(type=<Type.ID: 2>, version=19, hash_len=32, "
-            "salt_len=8, time_cost=2, memory_cost=65536, parallelelism=4)>"
+            "salt_len=8, time_cost=2, memory_cost=65536, parallelism=4)>"
             == repr(
                 Parameters(
                     type=Type.ID,


### PR DESCRIPTION
I tried but I couldn't build the project on my system. It's just a type error fix, use it if you want, ignore/close otherwise. It was just frustrating that I wasn't able to get the parallelism variable from the parameters. Took me a bit to figure out that it was because it was spelled differently in the __repr__.