### PR TITLE
build abi3 wheels for windows as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,11 +341,7 @@ class BuildCLibWithCompilerFlags(build_clib):
             )
 
 
-if (
-    sys.platform != "win32"
-    and sys.version_info > (3,)
-    and platform.python_implementation() == "CPython"
-):
+if sys.version_info > (3,) and platform.python_implementation() == "CPython":
     try:
         import wheel.bdist_wheel
     except ImportError:


### PR DESCRIPTION
relates to #66

this doesn't solve the build-and-upload problem, but it will allow us to build future-proof distributions on windows (as we're already doing for linux / macos)