### PR TITLE
Improve cli duration output

### DIFF
--- a/src/argon2/__main__.py
+++ b/src/argon2/__main__.py
@@ -29,7 +29,7 @@ def main(argv):
         "-m", type=int, help="`memory_cost`", default=DEFAULT_MEMORY_COST
     )
     parser.add_argument(
-        "-p", type=int, help="`parallellism`", default=DEFAULT_PARALLELISM
+        "-p", type=int, help="`parallelism`", default=DEFAULT_PARALLELISM
     )
     parser.add_argument(
         "-l", type=int, help="`hash_length`", default=DEFAULT_HASH_LENGTH

--- a/src/argon2/__main__.py
+++ b/src/argon2/__main__.py
@@ -81,7 +81,9 @@ gc.enable()""".format(
         number=args.n,
     )
     print(
-        "\n{0:.3}ms per password verification".format(duration / args.n * 1000)
+        "\n{0:.1f}ms per password verification".format(
+            duration / args.n * 1000
+        )
     )
 
 


### PR DESCRIPTION
The format currently used to ouput the duration of the password verification in the CLI works well when the duration is < 100 ms, but it displays it with scientific notation when it's >= 100ms:
```python
>>> n = 1
>>> duration = 0.10012616399990293
>>> print("{0:.3}ms per password verification".format(duration / n * 1000))
1e+02ms per password verification
```

Using `.1f` ensures that the whole number part stays as is, and that only one digit is kept for the decimal part:
```python
>>> n = 1
>>> duration = 0.10012616399990293
>>> print("{0:.1f}ms per password verification".format(duration / n * 1000))
100.1ms per password verification
```