### PR TITLE
RFC9106: change defaults and add profiles

### DIFF
--- a/src/argon2/__init__.py
+++ b/src/argon2/__init__.py
@@ -1,4 +1,4 @@
-from . import exceptions, low_level
+from . import exceptions, low_level, profiles
 from ._legacy import hash_password, hash_password_raw, verify_password
 from ._password_hasher import (
     DEFAULT_HASH_LENGTH,
@@ -42,4 +42,5 @@ __all__ = [
     "hash_password_raw",
     "low_level",
     "verify_password",
+    "profiles",
 ]

--- a/src/argon2/_password_hasher.py
+++ b/src/argon2/_password_hasher.py
@@ -5,11 +5,11 @@ from .exceptions import InvalidHash
 from .low_level import Type, hash_secret, verify_secret
 
 
-DEFAULT_RANDOM_SALT_LENGTH = 16
-DEFAULT_HASH_LENGTH = 16
-DEFAULT_TIME_COST = 2
-DEFAULT_MEMORY_COST = 102400
-DEFAULT_PARALLELISM = 8
+DEFAULT_RANDOM_SALT_LENGTH = 16  # 128-bit salt
+DEFAULT_HASH_LENGTH = 32  # 256-bit tag size
+DEFAULT_TIME_COST = 3  # 3 iterations
+DEFAULT_MEMORY_COST = 65536  # m=2^(16) (64 MiB of RAM)
+DEFAULT_PARALLELISM = 4  # 4 lanes
 
 
 def _ensure_bytes(s, encoding):
@@ -118,6 +118,29 @@ class PasswordHasher:
     @property
     def type(self):
         return self._parameters.type
+
+    @classmethod
+    def from_profile(self, profile):
+        """
+        Create a new *PasswordHasher* from a profile.
+
+        :param profile: Profile providing parameters.
+        :type profile: ``Profile``
+
+        :rtype: PasswordHasher
+        """
+        return PasswordHasher(
+            time_cost=profile.time_cost,
+            memory_cost=profile.memory_cost,
+            parallelism=profile.parallelism,
+            hash_len=profile.hash_len,
+            salt_len=profile.salt_len,
+            # QUESTION: encoding and type could also be made optional by making
+            # them Optional in Profile and defaulting them to None to prevent
+            # duplicate defaults; PasswordHasher provides defaults already
+            encoding=profile.encoding,
+            type=profile.type,
+        )
 
     def hash(self, password):
         """

--- a/src/argon2/profiles.py
+++ b/src/argon2/profiles.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from .low_level import Type
+
+
+@dataclass(frozen=True)
+class Profile:
+    time_cost: int
+    memory_cost: int
+    parallelism: int
+    hash_len: int
+    salt_len: int
+    encoding: str = "utf-8"
+    type: Type = Type.ID
+
+
+RFC9106HighMemory = Profile(
+    time_cost=1, memory_cost=2097152, parallelism=4, hash_len=32, salt_len=16
+)
+
+RFC9106HighMemory = Profile(
+    time_cost=3, memory_cost=65536, parallelism=4, hash_len=32, salt_len=16
+)
+
+# QUESTION: this is named after the current released version.
+# Not sure of best naming strategy here.
+# could also go in _legacy.py?
+Legacy2110 = Profile(
+    time_cost=2, memory_cost=102400, parallelism=8, hash_len=16, salt_len=16
+)


### PR DESCRIPTION
# Description of changes
Change the default parameter choice to [RFC9106](https://datatracker.ietf.org/doc/html/rfc9106)'s recommended "low memory" option and provide named profiles for both high-memory (recommended on systems that can support it) and low-memory profiles.
```python
ph = PasswordHasher.from_profile(argon2.profiles.RFC9106HighMemory)
```

Also adds the ability to create `Profile` instances (or subclasses) that wrap `PasswordHasher`'s parameters.
```python
my_profile = argon2.profiles.Profile(time_cost=1, memory_cost=2, parallelism=3, hash_len=4, salt_len=5)
ph = PasswordHasher.from_profile(my_profile)
```

# Remaining tasks
- [ ] Provide documention/changelog.
- [ ] Write tests

Both of these will be done when the implementation strategy is confirmed

# Questions
- [ ] *Singletons vs subclasses*: The named RFC9106 profiles are implemented as import-time `Profile` singletons. Another option would be to subclass `Profile` and exclude the values from the `__init__` provided from dataclasses. This comes with inconsistent initialization behavior between `Profile` and its provided subclasses but avoids singletons. This would be okay if `Profile` was no longer exposed to the user.
- [ ] *Duplicated parameters*: Currently, `Profile` defaults `encoding` and `type` just as `PasswordHasher` does. If we want to avoid this duplication, we could remove all defaults from `Profile` and enforce all parameters are explicit.

Closes #101 