### PR TITLE
Remove errant reference to structlog

### DIFF
--- a/src/argon2/__init__.py
+++ b/src/argon2/__init__.py
@@ -67,7 +67,7 @@ def __getattr__(name: str) -> str:
     warnings.warn(
         f"Accessing argon2.{name} is deprecated and will be "
         "removed in a future release. Use importlib.metadata directly "
-        "to query for structlog's packaging metadata.",
+        "to query for argon2-cffi's packaging metadata.",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
Fix an apparent copy/paste error in a deprecation warning.

I spotted this in the warnings Warehouse's tests emit:

```
...
tests/unit/accounts/test_services.py::TestDatabaseUserService::test_get_recovery_codes
tests/unit/accounts/test_services.py::TestDatabaseUserService::test_create_login_success
  /opt/warehouse/lib/python3.12/site-packages/passlib/handlers/argon2.py:716: DeprecationWarning: Accessing argon2.__version__ is deprecated and will be removed in a future release. Use importlib.metadata directly to query for structlog's packaging metadata.
    _argon2_cffi.__version__, max_version)
...
```