### PR TITLE
Add a multithreaded stress test

### DIFF
--- a/tests/test_password_hasher.py
+++ b/tests/test_password_hasher.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MIT
 
+import secrets
+import sys
+import threading
+
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import pytest
@@ -194,3 +199,35 @@ class TestPasswordHasher:
             hash = ph.hash("hello")
 
             assert ph.verify(hash, "hello") is True
+
+
+def test_multithreaded_hashing():
+    hasher = PasswordHasher(parallelism=2)
+
+    num_passwords = 100
+
+    passwords = [secrets.token_urlsafe(15) for _ in range(num_passwords)]
+
+    def closure(b, passwords):
+        b.wait()
+        for password in passwords:
+            assert hasher.verify(hasher.hash(password), password)
+
+    max_workers = 4
+
+    chunks = [passwords[i::max_workers] for i in range(max_workers)]
+    orig_interval = sys.getswitchinterval()
+
+    with ThreadPoolExecutor(max_workers=max_workers) as tpe:
+        barrier = threading.Barrier(max_workers)
+        futures = []
+        try:
+            sys.setswitchinterval(.00001)
+            for chunk in chunks:
+                futures.append(tpe.submit(closure, barrier, chunk))
+        finally:
+            sys.setswitchinterval(orig_interval)
+            if len(futures) < max_workers:
+                barrier.abort()
+        for f in futures:
+            f.result()

--- a/tests/test_password_hasher.py
+++ b/tests/test_password_hasher.py
@@ -224,7 +224,7 @@ def test_multithreaded_hashing():
         try:
             sys.setswitchinterval(0.00001)
             for chunk in chunks:
-                futures.append(tpe.submit(closure, barrier, chunk))
+                futures.append(tpe.submit(closure, barrier, chunk))  # noqa: PERF401
         finally:
             sys.setswitchinterval(orig_interval)
             if len(futures) < max_workers:

--- a/tests/test_password_hasher.py
+++ b/tests/test_password_hasher.py
@@ -202,6 +202,9 @@ class TestPasswordHasher:
 
 
 def test_multithreaded_hashing():
+    """
+    Hash passwords in a thread pool and check for thread safety
+    """
     hasher = PasswordHasher(parallelism=2)
 
     num_passwords = 100

--- a/tests/test_password_hasher.py
+++ b/tests/test_password_hasher.py
@@ -222,7 +222,7 @@ def test_multithreaded_hashing():
         barrier = threading.Barrier(max_workers)
         futures = []
         try:
-            sys.setswitchinterval(.00001)
+            sys.setswitchinterval(0.00001)
             for chunk in chunks:
                 futures.append(tpe.submit(closure, barrier, chunk))
         finally:


### PR DESCRIPTION
Adds a test that runs the argon2 C hashing code in several Python threads on a shared `PasswordHasher` object. I don't see any issues on the GIL-enabled or free-threaded build. That said, I haven't tried yet with a TSAN python build, so there might be undetected benign races happening.

Setting `sys.setswitchinterval` to a small value increases the chances that a thread switch in pure python code causes a race condition.

This doesn't test error paths at all, it just runs hashing and verification in a thread pool and we expect `verify` to always succeed.

c.f. https://github.com/hynek/argon2-cffi-bindings/pull/70#issuecomment-2812271377
