### PR TITLE
Run tests against 3.14t, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: hynek/setup-cached-uv@v2
 
       - name: Run tests
-        run: >
+        run: |
           uv venv --python $PYTHON
           # cffi 2 is required and currently beta.
           uv pip install --prerelease=allow dist/*.whl --group dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,42 @@ jobs:
           --installpkg dist/*.whl
           -e py${PYTHON//./}-mypy
 
+  free-threading:
+    name: Test free-threaded builds on ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.14t
+    env:
+      PYTHON: ${{ matrix.python-version }}
+
+    steps:
+      - name: Download pre-built packages
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+      - run: |
+          tar xf dist/*.tar.gz --strip-components=1
+          rm -rf src
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - uses: hynek/setup-cached-uv@v2
+
+      - name: Run tests
+        run: >
+          uv venv --python $PYTHON
+          # cffi 2 is required and currently beta.
+          uv pip install --prerelease=allow dist/*.whl --group dev
+
+          pytest tests
+
 
   coverage:
     name: Ensure 100% test coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           # cffi 2 is required and currently beta.
           uv pip install --prerelease=allow dist/*.whl --group dev
 
-          pytest tests
+          .venv/bin/python -Im pytest tests
 
 
   coverage:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ min_version = 4
 env_list =
     pre-commit,
     mypy-pkg,
-    py3{9,10,11,12,13,14}-{tests,mypy}
+    py3{9,10,11,12,13,14}-{tests,mypy},
+    py314t-tests,
     py312-bindings-main,
     pypy3-tests,
     system-argon2,


### PR DESCRIPTION
Sadly, this is a bit convoluted because of https://github.com/hynek/build-and-inspect-python-package/issues/175 and the current state of CFFI.